### PR TITLE
ci: update Go versions to 1.25 and 1.26

### DIFF
--- a/.github/workflows/go.yaml
+++ b/.github/workflows/go.yaml
@@ -8,8 +8,8 @@ jobs:
     strategy:
       matrix:
         go:
-          - 1.15
-          - 1.16
+          - 1.25
+          - 1.26
     name: Build
     runs-on: ubuntu-latest
     steps:


### PR DESCRIPTION
closes  #23

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/k-hal/go-playground/26)
<!-- Reviewable:end -->
